### PR TITLE
issue 07, 08

### DIFF
--- a/src/svg-part-editor.html
+++ b/src/svg-part-editor.html
@@ -40,6 +40,22 @@
           <p id="status" class="text-sm text-gray-500">
             Select an SVG file to read its text.
           </p>
+          <div class="flex flex-wrap gap-3">
+            <button
+              id="serialize-btn"
+              type="button"
+              class="rounded-lg border border-gray-200 bg-gray-900 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white hover:bg-gray-800"
+            >
+              Serialize SVG
+            </button>
+            <button
+              id="download-btn"
+              type="button"
+              class="rounded-lg border border-gray-200 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-widest text-gray-700 hover:bg-gray-100"
+            >
+              Download SVG
+            </button>
+          </div>
         </div>
       </section>
       <section class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
@@ -69,6 +85,9 @@
       const status = document.getElementById("status");
       const output = document.getElementById("svg-text");
       const stage = document.getElementById("stage");
+      const serializeButton = document.getElementById("serialize-btn");
+      const downloadButton = document.getElementById("download-btn");
+      let currentSvg = null;
 
       const ensureViewBox = (svg) => {
         const viewBox = svg.getAttribute("viewBox");
@@ -131,15 +150,53 @@
             svg.setAttribute("width", "100%");
             svg.setAttribute("height", "100%");
             requestAnimationFrame(() => ensureViewBox(svg));
+            currentSvg = svg;
           } else {
             stage.textContent = "No <svg> element found.";
+            currentSvg = null;
           }
         } catch (error) {
           status.textContent = "Failed to read file.";
           output.value = "";
           stage.textContent = "Failed to parse SVG.";
+          currentSvg = null;
           console.error(error);
         }
+      });
+
+      const serializeCurrentSvg = () => {
+        if (!currentSvg) {
+          status.textContent = "No SVG loaded to serialize.";
+          output.value = "";
+          return null;
+        }
+        const serializer = new XMLSerializer();
+        const serialized = serializer.serializeToString(currentSvg);
+        output.value = serialized;
+        status.textContent = `Serialized SVG (${serialized.length} chars).`;
+        console.info("SVG serialized length (chars):", serialized.length);
+        return serialized;
+      };
+
+      serializeButton.addEventListener("click", () => {
+        serializeCurrentSvg();
+      });
+
+      downloadButton.addEventListener("click", () => {
+        const serialized = serializeCurrentSvg();
+        if (!serialized) {
+          return;
+        }
+        const blob = new Blob([serialized], { type: "image/svg+xml" });
+        const url = URL.createObjectURL(blob);
+        const anchor = document.createElement("a");
+        anchor.href = url;
+        anchor.download = "edited.svg";
+        document.body.append(anchor);
+        anchor.click();
+        anchor.remove();
+        URL.revokeObjectURL(url);
+        console.info("SVG download triggered.");
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- add serialize button to convert current SVG to text
- add download button to save SVG as a file
- keep status + textarea in sync with serialized output

## Issues
Closes #07
Closes #08

## Test
- Load an SVG in `src/svg-part-editor.html`
- Click Serialize to update textarea
- Click Download to save `edited.svg`
