### PR TITLE
 同名ファイルを連続で開けるように　、Serialize SVG ボタンを Reset View の後ろに移動

### DIFF
--- a/src/svg-part-editor.html
+++ b/src/svg-part-editor.html
@@ -523,6 +523,7 @@
             console.info("SVG path count:", pathCount);
             console.info("SVG element count:", nodeCount);
           }
+          fileInput.value = "";
         } catch (error) {
           status.textContent = "Failed to read file.";
           output.value = "";


### PR DESCRIPTION
svg-part-editor.html: 同名ファイルを連続で開けるように、読み込み後に fileInput.value = "" を追加。
svg-part-editor.html: Serialize SVG ボタンを Reset View の後ろに移動し、区切り線付きの開発用グループとして配置。