### PR TITLE
Issue 31.3: 新規 Part 作成機能の検討 を少し進める

### DIFF
--- a/docs/ISSUE_LIST.md
+++ b/docs/ISSUE_LIST.md
@@ -263,6 +263,10 @@
 - 作成対象のPart種別（例: rect/circle/path など）が整理されている  
 - UI導線（ツール/メニュー/ショートカット等）の案が決まっている  
 - 参照構造や `<g>` 最小単位との整合性が検討されている  
+**メモ**
+- 初期バージョン対象: rect / circle / ellipse / line  
+- 初期バージョン対象外: path / polygon / polyline / text / image / g  
+- 推奨順: 基本図形作成（rect/circle/ellipse/line）→ 複数選択 → グループ化（g）  
 
 ---
 


### PR DESCRIPTION
Issue 31.3: 新規 Part 作成機能の検討 を少し進める

- 初期バージョン対象: rect / circle / ellipse / line
- 初期バージョン対象外: path / polygon / polyline / text / image / g
- 推奨順: 基本図形作成（rect/circle/ellipse/line）→ 複数選択 → グループ化（g）
